### PR TITLE
Update GitHub Actions workflow to include sandbox branch and test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,20 +2,24 @@ name: Python Application Test with Github Actions
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, sandbox ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, sandbox ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
This commit updates the `.github/workflows/main.yml` file to trigger on pushes and pull requests to both the `main` and `sandbox` branches. It introduces a `strategy.matrix` to test against Python versions `3.10`, `3.11`, and `3.12`. The checkout and setup-python actions were upgraded to `v4` and `v5` respectively, with pip dependency caching added as a best practice.

---
*PR created automatically by Jules for task [973511640189163395](https://jules.google.com/task/973511640189163395) started by @Vespertili0*