### PR TITLE
fix: resolve technical debt in dashboard, backtester, and database

### DIFF
--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -63,11 +63,18 @@ def get_stock_data(conn, ticker):
         st.error(f"Error fetching stock data: {e}")
         return pd.DataFrame()
 
+import json
+
 def get_backtest_results(conn):
     """Fetches backtest results."""
     try:
         query = "SELECT * FROM backtest_results"
         df = pd.read_sql_query(query, conn)
+        if not df.empty and 'metrics' in df.columns:
+            # Parse JSON metrics and expand into columns
+            df['metrics'] = df['metrics'].apply(lambda x: json.loads(x) if isinstance(x, str) else x)
+            metrics_df = pd.json_normalize(df['metrics'])
+            df = pd.concat([df.drop('metrics', axis=1), metrics_df], axis=1)
         return df
     except Exception as e:
         st.error(f"Error fetching backtest results: {e}")

--- a/pyquantflow/backtesting/batchbacktest.py
+++ b/pyquantflow/backtesting/batchbacktest.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import numpy as np
 from typing import Optional, Dict, List, Any, Tuple, Union
+import warnings
 from backtesting import Backtest
 from .backtest_database import BacktestDatabaseManager
 from ..data.assetorganiser import AssetOrganiser
@@ -40,9 +41,17 @@ class BatchBacktester:
         if not isinstance(df.index, pd.DatetimeIndex):
             df.index = pd.to_datetime(df.index, utc=True)
         
-        bt = Backtest(df, strategy_class, cash=cash, commission=commission,
+        # Adding margin to backtest instantiation allows size scaling and reduces margin errors natively if applicable
+        # The margin argument requires a float in backtesting.py
+        margin = strategy_params.pop('margin', 1.0)
+
+        bt = Backtest(df, strategy_class, cash=cash, commission=commission, margin=margin,
                       trade_on_close=trade_on_close, finalize_trades=finalize_trades)
-        stats = bt.run(**strategy_params)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=".*Broker canceled the relative-sized order due to insufficient margin.*")
+            stats = bt.run(**strategy_params)
+
         return stats.to_dict()
 
     def run_batch_backtest(self, strategy_class: type, 

--- a/pyquantflow/data/database.py
+++ b/pyquantflow/data/database.py
@@ -177,8 +177,12 @@ class DatabaseManager:
         # We should probably maintain consistency.
         try:
             new_data.index = new_data.index.tz_convert('Australia/Sydney')
-        except Exception:
-            pass # If conversion fails (e.g. naive), skip or handle
+        except TypeError:
+            # If conversion fails due to naive index, localize to UTC then convert
+            if new_data.index.tz is None:
+                new_data.index = new_data.index.tz_localize('UTC').tz_convert('Australia/Sydney')
+        except Exception as e:
+            print(f"Warning: Timezone conversion failed for {ticker}. Proceeding with current index. Error: {e}")
 
         self._insert_price_data(ticker_id, new_data)
         


### PR DESCRIPTION
This PR implements the 3 Quick Fixes identified in the codebase audit:

1. **Dashboard Improvements**: Modified `dashboard.py` to parse the raw JSON string `metrics` from `backtest_results.db` using `json.loads` and expanded it via `pd.json_normalize` so the results are displayed in clean, sortable columns.
2. **Backtesting Warnings Mitigation**: Modified `BatchBacktester.run_single_backtest` to extract a `margin` kwarg (defaulting to 1.0) and pass it explicitly to `Backtest`. Also added a `warnings.catch_warnings()` context manager to filter out the persistent "Broker canceled the relative-sized order due to insufficient margin" spam from the logs.
3. **Database Error Handling**: Modified `DatabaseManager.update_ticker` to explicitly catch `TypeError` during timezone conversion (`tz_convert`). Naive indexes are now correctly localized to 'UTC' before converting to 'Australia/Sydney', instead of silently passing on errors. Unforeseen exceptions print a clear warning rather than being completely swallowed.

---
*PR created automatically by Jules for task [13791135256872863972](https://jules.google.com/task/13791135256872863972) started by @Vespertili0*