### PR TITLE
Fix test_assetorganiser_training and AssetOrganiser issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ venv/
 .env
 .DS_Store
 stocks.db
+mlruns/
+mlflow.db

--- a/pyquantflow/model/manager.py
+++ b/pyquantflow/model/manager.py
@@ -142,7 +142,8 @@ class ClassifierEngine(BaseModelEngine):
                 signature=signature
             )
             mlflow.log_params(params)
-            mlflow.set_tags(tags)
+            if tags is not None:
+                mlflow.set_tags(tags)
 
             # Evaluate
             _ = mlflow.models.evaluate(

--- a/tests/test_assetorganiser_training.py
+++ b/tests/test_assetorganiser_training.py
@@ -36,12 +36,14 @@ class TestDataHierarchyIntegration(unittest.TestCase):
             "target": np.random.randint(0, 2, 10),
             "weight": np.random.uniform(0.5, 1.5, 10)
         }, index=dates)
+        df_a.index.name = "datetime"
         
         df_b = pd.DataFrame({
             "feature1": np.random.randn(10),
             "target": np.random.randint(0, 2, 10),
             "weight": np.random.uniform(0.5, 1.5, 10)
         }, index=dates)
+        df_b.index.name = "datetime"
 
         self.data_map = {"AAA": df_a, "BBB": df_b}
 
@@ -54,7 +56,7 @@ class TestDataHierarchyIntegration(unittest.TestCase):
             weight_col="weight"
         )
         organiser.prepare_multi_asset_frame()
-        payload = organiser.get_classifier_engine_payload()
+        payload = organiser.get_classifierengine_payload(features=["feature1"])
         
         # Verify payload structure
         self.assertIn("feature1", payload["features"])


### PR DESCRIPTION
This PR resolves the `KeyError: "None of ['datetime'] are in the columns"` failure in `test_assetorganiser_training.py` which occurred because the generated mock DataFrame indexes lacked names. It also fixes an outdated `AssetOrganiser` method call and missing parameter within the test itself. Additionally, a missing null check for tags during MLFlow registration in `pyquantflow/model/manager.py` was introduced to fix an `AttributeError`, and the resulting MLflow database/artifacts are added to `.gitignore`.

---
*PR created automatically by Jules for task [12367011126335366099](https://jules.google.com/task/12367011126335366099) started by @Vespertili0*