### PR TITLE
Update release workflow to remove PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish Python Package
+name: Create GitHub Release
 
 on:
   push:
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-publish:
-    name: Build and publish Python distribution
+  build-and-release:
+    name: Build Python distribution and create GitHub Release
     runs-on: ubuntu-latest
     
     steps:
@@ -22,15 +22,10 @@ jobs:
     - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build twine
+        pip install build
         
     - name: Build a binary wheel and a source tarball
       run: python -m build
-
-    - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Modify the `.github/workflows/release.yml` file to reflect creating a GitHub Release without publishing the package to PyPI, according to the user's intent.

---
*PR created automatically by Jules for task [5453163835741718361](https://jules.google.com/task/5453163835741718361) started by @Vespertili0*