### PR TITLE
Update Documentation for Major Merge (v0.2.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,15 @@ The SQLite database (`stocks.db`) has two main tables:
 The Backtest Results database (`backtest_results.db`) has one main table:
 1. `backtest_results`: Stores results of backtest runs (`id`, `ticker`, `batch_run_name`, `metrics`).
 
-### CI/CD
+### CI/CD & Automation Scripts
 A GitHub Actions workflow is set up in `.github/workflows/tests.yml`. It runs `unittest` tests via `python -m unittest discover tests` on Push and Pull Request to `main` and `dev` branches across Python versions 3.10 to 3.12. A separate `release.yml` handles releases.
+
+There is a modular AI automation architecture residing under `.github/scripts/`:
+- `jules_utils.mjs`: Centralised utility functions, including streaming event listeners and GitHub API interactions.
+- `jules_dev_pr_review.mjs`: Orchestrates PR reviews for `dev` branches.
+- `jules_main_notes.mjs`: Generates release notes for the `main` branch.
+
+**Security Note:** All automation scripts must rigorously sanitise untrusted inputs (e.g., PR titles and bodies) before passing them to prompt engines or API wrappers. Specifically, enforce backtick replacement (e.g. replacing ``` ` ``` with `\uFF40`) to prevent prompt injection and execution attacks.
 
 ## Current Status
 - Core SQLite database managers for market data and batch backtesting results are fully implemented.

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ organiser.prepare_multi_asset_frame()
 calibrated_alphas = organiser.build_learning_pipeline(
     target_events_train=1000,
     price_col="Close",
-    objective="budget"  # Targets a specific budget of events (e.g. 1000)
+    objective="budget",  # Targets a specific budget of events (e.g. 1000)
 )
 
 # 4. Extract Payload for MLOps Engine
@@ -164,6 +164,7 @@ organiser.apply_ichimoku_regime(mode="strict", displacement=26)
 
 # Use the stateless baseline classifier for fair cross-validation comparisons
 from pyquantflow.model.classifier import IchimokuBaselineClassifier
+
 baseline_model = IchimokuBaselineClassifier(regime_col="ichimoku_regime")
 ```
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ organiser = AssetOrganiser(
 #   c) Sample Weighting via Concurrency
 organiser.prepare_multi_asset_frame()
 calibrated_alphas = organiser.build_learning_pipeline(
-    target_events_train=1000, price_col="Close"
+    target_events_train=1000,
+    price_col="Close",
+    objective="budget"  # Targets a specific budget of events (e.g. 1000)
 )
 
 # 4. Extract Payload for MLOps Engine
@@ -147,6 +149,22 @@ payload = organiser.get_classifierengine_payload(features=["Close", "EMA_120"])
 # 5. Run MLOps Workflow
 engine = ClassifierEngine(optimiser=HyperparameterOptimiser(study_name="example"))
 # engine.run_pipeline(**payload, balance_classes=True, ...)
+```
+
+#### Multi-mode Market Regimes & Baselines
+
+You can explicitly label market regimes and inject them as features. `AssetOrganiser.apply_ichimoku_regime()` calculates Ichimoku Cloud regimes with three configurable modes:
+- **`standard`**: Price is above the cloud.
+- **`confirmed`**: Standard + bullish forward cloud + positive short-term momentum.
+- **`strict`**: Confirmed + Chikou Span breakout (configurable via `displacement`).
+
+```python
+# Inject 'ichimoku_regime' into the multi-asset feature matrix
+organiser.apply_ichimoku_regime(mode="strict", displacement=26)
+
+# Use the stateless baseline classifier for fair cross-validation comparisons
+from pyquantflow.model.classifier import IchimokuBaselineClassifier
+baseline_model = IchimokuBaselineClassifier(regime_col="ichimoku_regime")
 ```
 
 ### 4. Evaluate Financial Features

--- a/pyquantflow/data/assetorganiser.py
+++ b/pyquantflow/data/assetorganiser.py
@@ -1,5 +1,14 @@
+"""
+Asset Organiser Module
+
+This module provides the AssetOrganiser class for preparing, aligning, and transforming
+multi-asset panel data suitable for quantitative machine learning pipelines. It orchestrates
+continuous labelling, dynamic CUSUM down-sampling, feature generation (such as Ichimoku regimes),
+and sample weight calculation while strictly preventing sequential data hazards.
+"""
+
 import pandas as pd
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 from scipy.stats import entropy
 from sklearn.base import BaseEstimator
 from .utils import (
@@ -92,7 +101,7 @@ class AssetOrganiser:
 
     def downsample_to_events(
         self,
-        events: pd.DatetimeIndex | list | set | Dict[str, pd.DatetimeIndex],
+        events: Union[pd.DatetimeIndex, list, set, Dict[str, pd.DatetimeIndex]],
     ) -> None:
         """
         Down-samples the multi-asset DataFrame to keep only the dates matching
@@ -133,7 +142,7 @@ class AssetOrganiser:
 
     def downsample_to_cusum_events(
         self,
-        target_events_train: int | Dict[str, int],
+        target_events_train: Union[int, Dict[str, int]],
         filter_col: str,
         vol_col: Optional[str] = None,
         span: int = 100,
@@ -394,7 +403,7 @@ class AssetOrganiser:
 
     def build_learning_pipeline(
         self,
-        target_events_train: int | Dict[str, int],
+        target_events_train: Union[int, Dict[str, int]],
         filter_col: str,
         price_col: str = "Close",
         vol_col: Optional[str] = None,
@@ -501,7 +510,7 @@ class AssetOrganiser:
         self,
         features: List[str],
         tickers: Optional[List[str]] = None,
-    ) -> Dict[str, pd.DataFrame | List[str] | str | None]:
+    ) -> Dict[str, Union[pd.DataFrame, List[str], str, None]]:
         """
         Extracts the prepared data and metadata into a dictionary suitable for
         unpacking (**kwargs) directly into `ClassifierEngine.run_pipeline`.
@@ -623,6 +632,12 @@ class AssetOrganiser:
         component columns are dropped immediately after the mask is created to
         keep the feature matrix clean. **No rows are dropped.** The method mutates
         ``self.multi_asset`` in-place and calls ``_split_train_test()`` at the end.
+
+        Args:
+            mode (str): The strictness mode for determining the bullish regime.
+                Must be one of "standard", "confirmed", or "strict".
+            displacement (int): The number of periods to shift Chikou Span for
+                breakout confirmation in "strict" mode. Defaults to 26.
         """
         if mode not in ("standard", "confirmed", "strict"):
             raise ValueError(

--- a/pyquantflow/data/labels/cusum.py
+++ b/pyquantflow/data/labels/cusum.py
@@ -1,14 +1,22 @@
+"""
+CUSUM Labelling Module
+
+This module provides implementations of the Symmetric CUSUM Filter as proposed
+by Marcos Lopez de Prado. It includes functions for extracting CUSUM events
+and JAX-accelerated functions for calibrating the optimal alpha threshold.
+"""
+
 import numpy as np
 import pandas as pd
 import jax
 import jax.numpy as jnp
 from jax import lax
-from typing import Optional
+from typing import Optional, Union
 
 
 def get_cusum_events(
     series: pd.Series,
-    threshold: float | pd.Series,
+    threshold: Union[float, pd.Series],
 ) -> pd.DatetimeIndex:
     """
     Symmetric CUSUM Filter as proposed by Marcos Lopez de Prado in


### PR DESCRIPTION
Updates repository documentation for the major merge from dev to main (v0.2.1).

*   **README.md**: Added usage examples for `apply_ichimoku_regime` (with mode and displacement parameters), `IchimokuBaselineClassifier`, and `calibrate_cusum_alpha(objective="budget")`.
*   **AGENTS.md**: Documented the modular CI architecture under `.github/scripts/` (`jules_utils.mjs`, `jules_dev_pr_review.mjs`, `jules_main_notes.mjs`) and added security guidelines regarding untrusted PR title/body sanitisation (`\uFF40` backtick replacement).
*   **Docstrings & Type Hints**: Polished module-level docstrings and type hints in `pyquantflow/data/assetorganiser.py` and `pyquantflow/data/labels/cusum.py` for clarity and broader compatibility (`Union` over `|`), using British spelling.

---
*PR created automatically by Jules for task [248514557533900229](https://jules.google.com/task/248514557533900229) started by @Vespertili0*